### PR TITLE
Fix #7: Hover requests for empty characters

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -108,5 +108,5 @@ let cssAdapter = new CodeMirrorAdapter(cssConnection, {
 }, cssEditor);
 let jsConnection = new LspWsConnection(js).connect(new WebSocket(js.serverUri));
 let jsAdapter = new CodeMirrorAdapter(jsConnection, {
-  quickSuggestionsDelay: 100,
+  quickSuggestionsDelay: 50,
 }, jsEditor);

--- a/src/ws-connection.ts
+++ b/src/ws-connection.ts
@@ -21,6 +21,7 @@ type ExtendedClientCapabilities = lsProtocol.ClientCapabilities & IFilesServerCl
 
 class LspWsConnection extends events.EventEmitter implements ILspConnection {
   private isConnected = false;
+  private isInitialized = false;
   private socket: WebSocket;
   private documentInfo: ILspOptions;
   private serverCapabilities: lsProtocol.ServerCapabilities;
@@ -133,6 +134,7 @@ class LspWsConnection extends events.EventEmitter implements ILspConnection {
     };
 
     this.connection.sendRequest('initialize', message).then((params: lsProtocol.InitializeResult) => {
+      this.isInitialized = true;
       this.serverCapabilities = params.capabilities as ServerCapabilities;
       const textDocumentMessage: lsProtocol.DidOpenTextDocumentParams = {
         textDocument: {
@@ -170,7 +172,7 @@ class LspWsConnection extends events.EventEmitter implements ILspConnection {
   }
 
   public getHoverTooltip(location: IPosition) {
-    if (!this.isConnected) {
+    if (!this.isInitialized) {
       return;
     }
     this.connection.sendRequest('textDocument/hover', {


### PR DESCRIPTION
This also fixes two other hover issues I discovered:

* The CodeMirror `coordsChar` function snaps to the nearest line, even if the requested coordinates are not within the CodeMirror instance
* There was a logic bug that prevented the hover call from firing twice within the same line