### PR TITLE
Fix bug with hover responses that don't contain a range

### DIFF
--- a/src/codemirror-adapter.ts
+++ b/src/codemirror-adapter.ts
@@ -125,14 +125,22 @@ class CodeMirrorAdapter extends IEditorAdapter<CodeMirror.Editor> {
       return;
     }
 
-    const start = {
-      line: response.range.start.line,
-      ch: response.range.start.character,
-    } as CodeMirror.Position;
-    const end = {
-      line: response.range.end.line,
-      ch: response.range.end.character,
-    } as CodeMirror.Position;
+    let start = this.hoverCharacter;
+    let end = this.hoverCharacter;
+    if (response.range) {
+      start = {
+        line: response.range.start.line,
+        ch: response.range.start.character,
+      } as CodeMirror.Position;
+      end = {
+        line: response.range.end.line,
+        ch: response.range.end.character,
+      } as CodeMirror.Position;
+
+      this.hoverMarker = this.editor.getDoc().markText(start, end, {
+        css: 'text-decoration: underline',
+      });
+    }
 
     let tooltipText;
     if (MarkupContent.is(response.contents)) {
@@ -149,10 +157,6 @@ class CodeMirrorAdapter extends IEditorAdapter<CodeMirror.Editor> {
     } else if (typeof response.contents === 'string') {
       tooltipText = response.contents;
     }
-
-    this.hoverMarker = this.editor.getDoc().markText(start, end, {
-      css: 'text-decoration: underline',
-    });
 
     const htmlElement = document.createElement('div');
     htmlElement.innerText = tooltipText;

--- a/test/codemirror-adapter.test.ts
+++ b/test/codemirror-adapter.test.ts
@@ -146,6 +146,33 @@ describe('CodeMirror adapter', () => {
       expect(document.querySelectorAll('.CodeMirror-lsp-tooltip').length).toEqual(1);
     });
 
+    it('should handle hover responses without ranges', () => {
+      const pos = {
+        line: 0,
+        ch: 3,
+      };
+      const screenPos = editor.charCoords(pos, 'window');
+
+      const target = editor.getWrapperElement().querySelector('.CodeMirror-line');
+      target.dispatchEvent(new MouseEvent('mousemove', {
+        clientX: screenPos.left,
+        clientY: screenPos.top,
+        bubbles: true,
+      }));
+
+      clock.tick(10);
+
+      connection.dispatchEvent(new MessageEvent('hover', {
+        data: {
+          contents: ['hello'],
+        },
+      }));
+
+      expect(editor.getDoc().getAllMarks().length).toEqual(0);
+
+      expect(document.querySelectorAll('.CodeMirror-lsp-tooltip').length).toEqual(1);
+    });
+
     it('should clear the hover if the server returns no results', () => {
       connection.dispatchEvent(new MessageEvent('hover', {
         data: {


### PR DESCRIPTION
Some language servers, like @sourcegraph/go-langserver, don't return ranges for hover. This PR adds a special case for the hover response which defaults to the last-known hover position.

Closes #11 
