### PR TITLE
Fix #16: handleHighlight null highlight error

### DIFF
--- a/src/codemirror-adapter.ts
+++ b/src/codemirror-adapter.ts
@@ -152,7 +152,7 @@ class CodeMirrorAdapter extends IEditorAdapter<CodeMirror.Editor> {
   }
 
   public handleHighlight(items: lsProtocol.DocumentHighlight[]) {
-    this._highlightRanges(items.map((i) => i.range));
+    this._highlightRanges((items || []).map((i) => i.range));
   }
 
   public handleCompletion(completions: lsProtocol.CompletionItem[]): void {

--- a/test/codemirror-adapter.test.ts
+++ b/test/codemirror-adapter.test.ts
@@ -240,7 +240,6 @@ describe('CodeMirror adapter', () => {
     beforeEach(() => {
       connection = new MockConnection();
 
-      // tslint:disable no-unused-expression
       adapter = new CodeMirrorAdapter(connection, {}, editor);
 
       editor.getDoc().replaceSelection('hello world hello there');
@@ -249,23 +248,15 @@ describe('CodeMirror adapter', () => {
     it('should highlight matching tokens', () => {
       connection.dispatchEvent(new MessageEvent('highlight', highlightMessageData));
 
-      const highlightedElements = document.querySelectorAll('[style*="background-color:"]');
-
-      expect(highlightedElements.length).toEqual(2);
-      expect(highlightedElements[0].textContent).toEqual('hello');
-      expect(highlightedElements[1].textContent).toEqual('hello');
+      expect(editor.getDoc().getAllMarks().length).toEqual(2);
     });
 
     it('should accept null highlight and remove highlights', () => {
-      let highlightedElements;
-
       connection.dispatchEvent(new MessageEvent('highlight', highlightMessageData));
-      highlightedElements = document.querySelectorAll('[style*="background-color:"]');
-      expect(highlightedElements.length).toEqual(2);
+      expect(editor.getDoc().getAllMarks().length).toEqual(2);
 
       connection.dispatchEvent(new MessageEvent('highlight', {data: null}));
-      highlightedElements = document.querySelectorAll('[style*="background-color:"]');
-      expect(highlightedElements.length).toEqual(0);
+      expect(editor.getDoc().getAllMarks().length).toEqual(0);
     });
   });
 

--- a/test/codemirror-adapter.test.ts
+++ b/test/codemirror-adapter.test.ts
@@ -205,6 +205,70 @@ describe('CodeMirror adapter', () => {
     });
   });
 
+  describe('token highlights', () => {
+    const highlightMessageData = {
+      data: [
+        {
+          range: {
+            start: {
+              line: 0,
+              character: 0,
+            },
+            end: {
+              line: 0,
+              character: 5,
+            },
+          },
+        },
+        {
+          range: {
+            start: {
+              line: 0,
+              character: 12,
+            },
+            end: {
+              line: 0,
+              character: 17,
+            },
+          },
+        },
+      ],
+    };
+
+    let connection: MockConnection;
+
+    beforeEach(() => {
+      connection = new MockConnection();
+
+      // tslint:disable no-unused-expression
+      adapter = new CodeMirrorAdapter(connection, {}, editor);
+
+      editor.getDoc().replaceSelection('hello world hello there');
+    });
+
+    it('should highlight matching tokens', () => {
+      connection.dispatchEvent(new MessageEvent('highlight', highlightMessageData));
+
+      const highlightedElements = document.querySelectorAll('[style*="background-color:"]');
+
+      expect(highlightedElements.length).toEqual(2);
+      expect(highlightedElements[0].textContent).toEqual('hello');
+      expect(highlightedElements[1].textContent).toEqual('hello');
+    });
+
+    it('should accept null highlight and remove highlights', () => {
+      let highlightedElements;
+
+      connection.dispatchEvent(new MessageEvent('highlight', highlightMessageData));
+      highlightedElements = document.querySelectorAll('[style*="background-color:"]');
+      expect(highlightedElements.length).toEqual(2);
+
+      connection.dispatchEvent(new MessageEvent('highlight', {data: null}));
+      highlightedElements = document.querySelectorAll('[style*="background-color:"]');
+      expect(highlightedElements.length).toEqual(0);
+    });
+  });
+
   describe('autocompletion', () => {
     let connection: MockConnection;
 


### PR DESCRIPTION
Fixes #16: documentHighlight request with null highlight throws an error. 

The specification says that it's possible to receive a null highlight: https://microsoft.github.io/language-server-protocol/specification#textDocument_documentHighlight

