### PR TITLE
This commit fixes 3 things.

### DIFF
--- a/src/codemirror-adapter.ts
+++ b/src/codemirror-adapter.ts
@@ -133,6 +133,8 @@ class CodeMirrorAdapter extends IEditorAdapter<CodeMirror.Editor> {
       const firstItem = response.contents[0];
       if (MarkupContent.is(firstItem)) {
         tooltipText = firstItem.value;
+      } else if (firstItem === null) {
+        return;
       } else if (typeof firstItem === 'object') {
         tooltipText = firstItem.value;
       } else {

--- a/src/ws-connection.ts
+++ b/src/ws-connection.ts
@@ -250,8 +250,12 @@ class LspWsConnection extends events.EventEmitter implements ILspConnection {
         triggerKind: triggerKind || lsProtocol.CompletionTriggerKind.Invoked,
         triggerCharacter,
       },
-    } as lsProtocol.CompletionParams).then((params: lsProtocol.CompletionList) => {
-      this.emit('completion', params ? params.items : null);
+    } as lsProtocol.CompletionParams).then((params: lsProtocol.CompletionList | lsProtocol.CompletionItem[] | null) => {
+      let result:any = params;
+      if (<lsProtocol.CompletionList>params && (<lsProtocol.CompletionList>params).items) {
+        result = (<lsProtocol.CompletionList>params).items;
+      }
+      this.emit('completion', result);
     });
   }
 
@@ -417,7 +421,7 @@ class LspWsConnection extends events.EventEmitter implements ILspConnection {
     if (!this.isConnected) {
       return;
     }
-    if (!(this.serverCapabilities && this.serverCapabilities.completionProvider)) {
+    if (!(this.serverCapabilities && this.serverCapabilities.completionProvider && this.serverCapabilities.completionProvider.triggerCharacters)) {
       return [];
     }
     return this.serverCapabilities.completionProvider.triggerCharacters;
@@ -430,7 +434,7 @@ class LspWsConnection extends events.EventEmitter implements ILspConnection {
     if (!this.isConnected) {
       return;
     }
-    if (!(this.serverCapabilities && this.serverCapabilities.signatureHelpProvider)) {
+    if (!(this.serverCapabilities && this.serverCapabilities.signatureHelpProvider && this.serverCapabilities.signatureHelpProvider.triggerCharacters)) {
       return [];
     }
     return this.serverCapabilities.signatureHelpProvider.triggerCharacters;

--- a/src/ws-connection.ts
+++ b/src/ws-connection.ts
@@ -251,11 +251,11 @@ class LspWsConnection extends events.EventEmitter implements ILspConnection {
         triggerCharacter,
       },
     } as lsProtocol.CompletionParams).then((params: lsProtocol.CompletionList | lsProtocol.CompletionItem[] | null) => {
-      let result:any = params;
-      if (<lsProtocol.CompletionList>params && (<lsProtocol.CompletionList>params).items) {
-        result = (<lsProtocol.CompletionList>params).items;
+      if (!params) {
+        this.emit('completion', params);
+        return;
       }
-      this.emit('completion', result);
+      this.emit('completion', 'items' in params ? params.items : params);
     });
   }
 
@@ -421,7 +421,11 @@ class LspWsConnection extends events.EventEmitter implements ILspConnection {
     if (!this.isConnected) {
       return;
     }
-    if (!(this.serverCapabilities && this.serverCapabilities.completionProvider && this.serverCapabilities.completionProvider.triggerCharacters)) {
+    if (!(
+      this.serverCapabilities &&
+      this.serverCapabilities.completionProvider &&
+      this.serverCapabilities.completionProvider.triggerCharacters
+    )) {
       return [];
     }
     return this.serverCapabilities.completionProvider.triggerCharacters;
@@ -434,7 +438,11 @@ class LspWsConnection extends events.EventEmitter implements ILspConnection {
     if (!this.isConnected) {
       return;
     }
-    if (!(this.serverCapabilities && this.serverCapabilities.signatureHelpProvider && this.serverCapabilities.signatureHelpProvider.triggerCharacters)) {
+    if (!(
+      this.serverCapabilities &&
+      this.serverCapabilities.signatureHelpProvider &&
+      this.serverCapabilities.signatureHelpProvider.triggerCharacters
+    )) {
       return [];
     }
     return this.serverCapabilities.signatureHelpProvider.triggerCharacters;

--- a/test/mock-connection.ts
+++ b/test/mock-connection.ts
@@ -39,7 +39,13 @@ export class MockConnection implements ILspConnection {
   public isReferencesSupported = sinon.stub();
   public close = sinon.stub();
 
-  constructor() {}
+  public completionCharacters: string[];
+  public signatureCharacters: string[];
+
+  constructor() {
+    this.completionCharacters = ['.', ','];
+    this.signatureCharacters = ['('];
+  }
 
   public on(type: string, listener: (arg: any) => void) {
     const listeners = this.listeners[type];
@@ -58,9 +64,9 @@ export class MockConnection implements ILspConnection {
   }
 
   public getLanguageCompletionCharacters() {
-    return ['.', ','];
+    return this.completionCharacters;
   }
   public getLanguageSignatureCharacters() {
-    return ['('];
+    return this.signatureCharacters;
   }
 }


### PR DESCRIPTION
1. Handle `textDocument/completion` result when result is `CompletionItem[]`. 
Before this commit, it was assumed `textDocument/completion` result would be type `CompletionList` or `null`. See https://microsoft.github.io/language-server-protocol/specification#completion-request-leftwards_arrow_with_hook

2. Handle null trigger characters for signatureHelp and completion.
Client would error if a language server registered SignatureHelp or Completion with no trigger characters. Example language server response that leads to an error:

```
Sent: {"id":9,"jsonrpc":"2.0","method":"client/registerCapability","params":{"registrations":[{"id":"43f30805-c2d9-4091-9693-68208feb617d","method":"textDocument/signatureHelp","registerOptions":{"triggerCharacters":null,"documentSelector":[{"pattern":"**/*.cs"},{"pattern":"**/*.csx"}]}}]}}
```

3. Some language servers (omnisharp) send a hover result with a `null` object in the content array. Added a return to handle this case. 

Example
```
Sent: {"jsonrpc":"2.0","id":29,"result":{"contents":[null,null]}}
```